### PR TITLE
Add Google Drive workflow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository provides scripts and instructions for preparing and training a m
 - `data/processed/` – Output directory for cleaned and deduplicated sentences.
 - `data/datasets/` – Output HuggingFace `DatasetDict` saved with `save_to_disk()`.
 - `scripts/` – Contains data processing and training scripts.
-- `notebooks/` – Optional Jupyter notebooks for exploratory data analysis and manual cleaning.
+- `notebooks/` – Jupyter notebooks including the Colab training workflow.
 
 ## Setup
 
@@ -17,21 +17,58 @@ This repository provides scripts and instructions for preparing and training a m
    pip install -r requirements.txt
    ```
 
-2. Add your raw text files to `data/raw/`.
+2. Add your raw text files to `data/raw/` (or pass a different path).
 
 3. Run the cleaning and splitting script:
    ```bash
-   python scripts/clean_and_split.py
+   python scripts/clean_and_split.py --raw_dir data/raw --processed_dir data/processed
    ```
 
 4. Create the dataset:
    ```bash
-   python scripts/create_dataset.py
+   python scripts/create_dataset.py --processed_file data/processed/cleaned_sentences.txt --dataset_dir data/datasets
    ```
 
 5. Train the model:
    ```bash
-   python scripts/train_nllb.py
+   python scripts/train_nllb.py --dataset_dir data/datasets --output_dir nllb_rutooro_finetuned
    ```
 
 Checkpoints and logs can be adjusted inside `scripts/train_nllb.py`.
+
+## Using Google Colab and Google Drive
+
+You can run the entire pipeline in Colab so that all data and model outputs are stored on your Google Drive.
+
+1. Open the training notebook in Colab:
+   [Open in Colab](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/rutooro-nllb-200-monolingual/blob/main/notebooks/rutooro_mlm_training.ipynb)
+
+2. Mount your Drive inside Colab:
+
+   ```python
+   from google.colab import drive
+   drive.mount('/content/drive')
+   ```
+
+3. Choose where to store your data and models on Drive by editing the paths in the notebook:
+
+   ```python
+   from pathlib import Path
+
+   RAW_DATA_DIR = Path('/content/drive/MyDrive/rutooro-mlm/data/raw')
+   PROCESSED_DATA_DIR = Path('/content/drive/MyDrive/rutooro-mlm/data/processed')
+   DATASETS_DIR = Path('/content/drive/MyDrive/rutooro-mlm/data/datasets')
+   MODEL_DIR = Path('/content/drive/MyDrive/rutooro-mlm/models/nllb_rutooro_finetuned')
+   ```
+
+4. Run the cells to clean the data, create the dataset, and fine‑tune the model. All outputs will be written to the directories above on your Drive so they persist after the Colab session ends.
+
+You can also execute the scripts directly in a Colab cell by specifying paths:
+
+```python
+!python scripts/clean_and_split.py --raw_dir $RAW_DATA_DIR --processed_dir $PROCESSED_DATA_DIR
+!python scripts/create_dataset.py --processed_file $PROCESSED_DATA_DIR/cleaned_sentences.txt --dataset_dir $DATASETS_DIR
+!python scripts/train_nllb.py --dataset_dir $DATASETS_DIR --output_dir $MODEL_DIR
+```
+
+After training you can download the model or continue working with it from Drive.

--- a/notebooks/rutooro_mlm_training.ipynb
+++ b/notebooks/rutooro_mlm_training.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "959d0e5a",
+   "metadata": {},
+   "source": [
+    "# Rutooro NLLB-200 MLM Training\n",
+    "This notebook runs the data preparation and training pipeline on Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f15ff1ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c8a3a4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount(\"/content/drive\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbc9a99f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "# Customize these paths as needed\n",
+    "RAW_DATA_DIR = Path(\"/content/drive/MyDrive/rutooro-mlm/data/raw\")\n",
+    "PROCESSED_DATA_DIR = Path(\"/content/drive/MyDrive/rutooro-mlm/data/processed\")\n",
+    "DATASETS_DIR = Path(\"/content/drive/MyDrive/rutooro-mlm/data/datasets\")\n",
+    "MODEL_DIR = Path(\"/content/drive/MyDrive/rutooro-mlm/models/nllb_rutooro_finetuned\")\n",
+    "\n",
+    "for p in [RAW_DATA_DIR, PROCESSED_DATA_DIR, DATASETS_DIR, MODEL_DIR]:\n",
+    "    p.mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d5b8c4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scripts.clean_and_split import clean_and_split\n",
+    "from scripts.create_dataset import create_dataset\n",
+    "from scripts.train_nllb import train\n",
+    "\n",
+    "cleaned_file = PROCESSED_DATA_DIR / \"cleaned_sentences.txt\"\n",
+    "clean_and_split(RAW_DATA_DIR, PROCESSED_DATA_DIR, cleaned_file)\n",
+    "create_dataset(cleaned_file, DATASETS_DIR)\n",
+    "train(DATASETS_DIR, \"facebook/nllb-200-distilled-600M\", MODEL_DIR)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/clean_and_split.py
+++ b/scripts/clean_and_split.py
@@ -1,12 +1,34 @@
 #!/usr/bin/env python
 import os
 import re
+import argparse
 from pathlib import Path
 from nltk import sent_tokenize
 
-RAW_DIR = Path('data/raw')
-PROCESSED_DIR = Path('data/processed')
-OUTPUT_FILE = PROCESSED_DIR / 'cleaned_sentences.txt'
+
+def clean_and_split(raw_dir: Path, processed_dir: Path, output_file: Path) -> None:
+    """Clean raw text files and split them into unique sentences."""
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    sentences = []
+    files_processed = 0
+    for txt_path in raw_dir.glob('*.txt'):
+        files_processed += 1
+        with open(txt_path, 'r', encoding='utf-8') as f:
+            text = f.read()
+        text = clean_text(text)
+        sents = sent_tokenize(text)
+        sentences.extend(sents)
+        print(f"Processed {txt_path} -> {len(sents)} sentences")
+
+    unique_sentences = list(dict.fromkeys(sentences))
+    with open(output_file, 'w', encoding='utf-8') as out_f:
+        for s in unique_sentences:
+            out_f.write(s + '\n')
+    print(f"Processed {files_processed} files")
+    print(f"Total sentences: {len(sentences)}")
+    print(f"Unique sentences: {len(unique_sentences)}")
+    print(f"Saved cleaned sentences to {output_file}")
 
 
 def clean_text(text: str) -> str:
@@ -18,26 +40,17 @@ def clean_text(text: str) -> str:
 
 
 def main():
-    PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
-    sentences = []
-    files_processed = 0
-    for txt_path in RAW_DIR.glob('*.txt'):
-        files_processed += 1
-        with open(txt_path, 'r', encoding='utf-8') as f:
-            text = f.read()
-        text = clean_text(text)
-        sents = sent_tokenize(text)
-        sentences.extend(sents)
-        print(f"Processed {txt_path} -> {len(sents)} sentences")
+    parser = argparse.ArgumentParser(description="Clean Rutooro text and split into sentences")
+    parser.add_argument("--raw_dir", type=Path, default=Path("data/raw"), help="Directory containing raw .txt files")
+    parser.add_argument("--processed_dir", type=Path, default=Path("data/processed"), help="Directory to store processed outputs")
+    parser.add_argument("--output_file", type=Path, default=None, help="Path to save cleaned sentences")
+    args = parser.parse_args()
 
-    unique_sentences = list(dict.fromkeys(sentences))
-    with open(OUTPUT_FILE, 'w', encoding='utf-8') as out_f:
-        for s in unique_sentences:
-            out_f.write(s + '\n')
-    print(f"Processed {files_processed} files")
-    print(f"Total sentences: {len(sentences)}")
-    print(f"Unique sentences: {len(unique_sentences)}")
-    print(f"Saved cleaned sentences to {OUTPUT_FILE}")
+    output_file = args.output_file
+    if output_file is None:
+        output_file = args.processed_dir / "cleaned_sentences.txt"
+
+    clean_and_split(args.raw_dir, args.processed_dir, output_file)
 
 
 if __name__ == '__main__':

--- a/scripts/create_dataset.py
+++ b/scripts/create_dataset.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
 import random
+import argparse
 from pathlib import Path
 from datasets import Dataset, DatasetDict
 
-PROCESSED_FILE = Path('data/processed/cleaned_sentences.txt')
-DATASET_DIR = Path('data/datasets')
 
+def create_dataset(processed_file: Path, dataset_dir: Path) -> None:
+    """Create a HuggingFace dataset from a cleaned sentence file."""
+    if not processed_file.exists():
+        raise FileNotFoundError(f"{processed_file} not found. Run clean_and_split.py first.")
+    dataset_dir.mkdir(parents=True, exist_ok=True)
 
-def main():
-    if not PROCESSED_FILE.exists():
-        raise FileNotFoundError(f"{PROCESSED_FILE} not found. Run clean_and_split.py first.")
-    DATASET_DIR.mkdir(parents=True, exist_ok=True)
-
-    with open(PROCESSED_FILE, 'r', encoding='utf-8') as f:
+    with open(processed_file, 'r', encoding='utf-8') as f:
         sentences = [line.strip() for line in f if line.strip()]
 
     random.shuffle(sentences)
@@ -23,11 +22,20 @@ def main():
     train_ds = Dataset.from_dict({'text': train_sentences})
     val_ds = Dataset.from_dict({'text': val_sentences})
     ds = DatasetDict({'train': train_ds, 'validation': val_ds})
-    ds.save_to_disk(DATASET_DIR)
+    ds.save_to_disk(dataset_dir)
 
-    print(f"Dataset saved to {DATASET_DIR}")
+    print(f"Dataset saved to {dataset_dir}")
     print(f"Train sentences: {len(train_sentences)}")
     print(f"Validation sentences: {len(val_sentences)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create HF dataset from cleaned text")
+    parser.add_argument("--processed_file", type=Path, default=Path("data/processed/cleaned_sentences.txt"), help="Path to cleaned sentence file")
+    parser.add_argument("--dataset_dir", type=Path, default=Path("data/datasets"), help="Output directory for dataset")
+    args = parser.parse_args()
+
+    create_dataset(args.processed_file, args.dataset_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/train_nllb.py
+++ b/scripts/train_nllb.py
@@ -1,34 +1,34 @@
 #!/usr/bin/env python
 from pathlib import Path
+import argparse
 from datasets import load_from_disk
-from transformers import (AutoTokenizer, AutoModelForMaskedLM,
-                          DataCollatorForLanguageModeling, Trainer,
-                          TrainingArguments)
-
-DATASET_DIR = Path('data/datasets')
-MODEL_NAME = 'facebook/nllb-200-distilled-600M'
-OUTPUT_DIR = Path('nllb_rutooro_finetuned')
-
-
-def tokenize_function(examples, tokenizer):
-    return tokenizer(examples['text'], truncation=True, padding='max_length', max_length=128)
+from transformers import (
+    AutoTokenizer,
+    AutoModelForMaskedLM,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
 
 
-def main():
-    if not DATASET_DIR.exists():
-        raise FileNotFoundError(f"{DATASET_DIR} not found. Run create_dataset.py first.")
+def train(dataset_dir: Path, model_name: str, output_dir: Path) -> None:
+    """Fine-tune the NLLB model on the provided dataset."""
+    if not dataset_dir.exists():
+        raise FileNotFoundError(f"{dataset_dir} not found. Run create_dataset.py first.")
 
-    dataset = load_from_disk(DATASET_DIR)
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
-    model = AutoModelForMaskedLM.from_pretrained(MODEL_NAME)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-    tokenized = dataset.map(lambda x: tokenize_function(x, tokenizer), batched=True, remove_columns=['text'])
+    dataset = load_from_disk(dataset_dir)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForMaskedLM.from_pretrained(model_name)
+
+    tokenized = dataset.map(lambda x: tokenize_function(x, tokenizer), batched=True, remove_columns=["text"])
     data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=True)
 
     training_args = TrainingArguments(
-        output_dir=str(OUTPUT_DIR),
-        evaluation_strategy='epoch',
-        save_strategy='epoch',
+        output_dir=str(output_dir),
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
         learning_rate=2e-5,
         num_train_epochs=3,
         per_device_train_batch_size=8,
@@ -41,14 +41,28 @@ def main():
     trainer = Trainer(
         model=model,
         args=training_args,
-        train_dataset=tokenized['train'],
-        eval_dataset=tokenized['validation'],
+        train_dataset=tokenized["train"],
+        eval_dataset=tokenized["validation"],
         data_collator=data_collator,
     )
 
     trainer.train()
-    trainer.save_model(OUTPUT_DIR)
-    print(f"Model trained and saved to {OUTPUT_DIR}")
+    trainer.save_model(output_dir)
+    print(f"Model trained and saved to {output_dir}")
+
+
+def tokenize_function(examples, tokenizer):
+    return tokenizer(examples["text"], truncation=True, padding="max_length", max_length=128)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fine-tune NLLB on Rutooro data")
+    parser.add_argument("--dataset_dir", type=Path, default=Path("data/datasets"), help="Directory containing HF dataset")
+    parser.add_argument("--model_name", type=str, default="facebook/nllb-200-distilled-600M", help="Base model name")
+    parser.add_argument("--output_dir", type=Path, default=Path("nllb_rutooro_finetuned"), help="Where to save the fine-tuned model")
+    args = parser.parse_args()
+
+    train(args.dataset_dir, args.model_name, args.output_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- refactor scripts to take input/output paths via argparse
- create training notebook with Drive paths and functions
- document Drive workflow in README

## Testing
- `python -m py_compile scripts/clean_and_split.py scripts/create_dataset.py scripts/train_nllb.py`
- `python scripts/clean_and_split.py --help`
- `python scripts/create_dataset.py --help`
- `python scripts/train_nllb.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68886d001e24832bbc274d2f35497c6f